### PR TITLE
fix(view-model): add composite disposable call

### DIFF
--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/presentation/FeedViewModel.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/presentation/FeedViewModel.kt
@@ -5,32 +5,30 @@ import com.leehendryp.stoneandroidchallenge.core.extensions.observeOnMain
 import com.leehendryp.stoneandroidchallenge.core.extensions.subscribeOnIO
 import com.leehendryp.stoneandroidchallenge.feed.domain.usecases.SearchJokeUseCase
 import com.leehendryp.stoneandroidchallenge.presentation.FeedState.Default
-import com.leehendryp.stoneandroidchallenge.presentation.FeedState.Error
-import com.leehendryp.stoneandroidchallenge.presentation.FeedState.Loading
-import com.leehendryp.stoneandroidchallenge.presentation.FeedState.Success
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.subscribeBy
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 import javax.inject.Inject
 
 class FeedViewModel @Inject constructor(
+    private val compositeDisposable: CompositeDisposable,
     private val searchJokeUseCase: SearchJokeUseCase
 ) : ViewModel() {
-    @Inject
-    lateinit var compositeDisposable: CompositeDisposable
 
     val state by lazy { BehaviorSubject.create<FeedState>().apply { onNext(Default) } }
 
     fun search(query: String) {
-        searchJokeUseCase.execute(query)
-            .subscribeOnIO()
-            .observeOnMain()
-            .doOnSubscribe { state(Loading) }
-            .doFinally { state(Default) }
-            .subscribeBy(
-                onSuccess = { jokeList -> state(Success(jokeList)) },
-                onError = { error -> state(Error(error)) }
-            )
+        compositeDisposable.add(
+            searchJokeUseCase.execute(query)
+                .subscribeOnIO()
+                .observeOnMain()
+                .doOnSubscribe { state(FeedState.Loading) }
+                .doFinally { state(Default) }
+                .subscribeBy(
+                    onSuccess = { jokeList -> state(FeedState.Success(jokeList)) },
+                    onError = { error -> state(FeedState.Error(error)) }
+                )
+        )
     }
 
     private fun state(feedState: FeedState) = state.onNext(feedState)

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/presentation/FeedViewModelTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/presentation/FeedViewModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.spyk
 import io.mockk.verifyOrder
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Observer
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -21,6 +22,7 @@ class FeedViewModelTest : RxUnitTest() {
     @get:Rule
     val taskExecutorRule = InstantTaskExecutorRule()
 
+    private lateinit var compositeDisposable: CompositeDisposable
     private lateinit var searchJokeUseCase: SearchJokeUseCase
     private lateinit var viewModel: FeedViewModel
 
@@ -29,7 +31,8 @@ class FeedViewModelTest : RxUnitTest() {
     @Before
     fun `set up`() {
         searchJokeUseCase = spyk()
-        viewModel = FeedViewModel(searchJokeUseCase)
+        compositeDisposable = spyk()
+        viewModel = FeedViewModel(compositeDisposable, searchJokeUseCase)
         initStateObserver()
     }
 


### PR DESCRIPTION
# Description

Add missing call to CompositeDisposable, which is a dependency of the FeedViewModel that could cause memory leaks if not properly managed. 

Closes #29 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have implemented remote config for the feature
