### PR TITLE
feat(share): make it possible to send jokes to other apps

### DIFF
--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/core/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/core/extensions/ViewExtensions.kt
@@ -33,6 +33,7 @@ fun SearchView.doOnQuerySubmit(block: (String) -> Unit) {
     setOnQueryTextListener(object : SearchView.OnQueryTextListener {
         override fun onQueryTextSubmit(query: String?): Boolean {
             query?.let { block(it) }
+            clearFocus()
             return true
         }
 

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/Mappers.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/Mappers.kt
@@ -13,17 +13,20 @@ fun List<JokeResponse>.toJokeList(): List<Joke> {
 fun JokeResponse.toJoke() = Joke(
     categories = categories ?: listOf(),
     updatedAt = updatedAt ?: "",
+    url = url ?: "",
     value = value ?: ""
 )
 
 fun RoomJoke.toJoke() = Joke(
     categories = categories,
     updatedAt = updatedAt,
+    url = url,
     value = value
 )
 
 fun Joke.toRoomJoke() = RoomJoke(
     categories = categories,
     updatedAt = updatedAt,
+    url = url,
     value = value
 )

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/local/database/RoomJoke.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/local/database/RoomJoke.kt
@@ -11,5 +11,6 @@ data class RoomJoke(
     val id: Int? = null,
     @NonNull @ColumnInfo(name = "categories") val categories: List<String>,
     @NonNull @ColumnInfo(name = "updated_at") val updatedAt: String,
+    @NonNull @ColumnInfo(name = "url") val url: String,
     @NonNull @ColumnInfo(name = "value") val value: String
 )

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/model/Joke.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/model/Joke.kt
@@ -5,5 +5,6 @@ import com.google.gson.annotations.SerializedName
 data class Joke(
     @SerializedName("categories") val categories: List<String>,
     @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("url") val url: String,
     @SerializedName("value") val value: String
 )

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedAdapter.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedAdapter.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.leehendryp.stoneandroidchallenge.R
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
+import kotlinx.android.synthetic.main.item_feed.view.icon_share
 import kotlinx.android.synthetic.main.item_feed.view.text_joke_category
 import kotlinx.android.synthetic.main.item_feed.view.text_joke_value
 
@@ -31,7 +32,7 @@ class FeedAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val currentJoke = jokes.toList()[position]
         holder.bind(currentJoke)
-        holder.itemView.setOnClickListener { onClickShare(currentJoke) }
+        holder.itemView.icon_share.setOnClickListener { onClickShare(currentJoke) }
     }
 
     fun update(jokes: Set<Joke>) {

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
@@ -83,7 +83,11 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
             feedAdapter = FeedAdapter(
                 context,
                 mutableSetOf(),
-                onClickShare = { joke -> startShareIntent(joke.value) }
+                onClickShare = { joke ->
+                    startShareIntent(
+                        String.format(getString(R.string.share_intent_message), joke.url)
+                    )
+                }
             )
         }
 

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
@@ -1,5 +1,8 @@
 package com.leehendryp.stoneandroidchallenge.feed.presentation.view
 
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_TEXT
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -34,6 +37,10 @@ import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 class FeedFragment : BaseFragment(), FreeTextSearcher {
+    companion object {
+        private const val SHARE_TYPE = "text/plain"
+    }
+
     private lateinit var binding: FragmentFeedBinding
 
     private lateinit var feedAdapter: FeedAdapter
@@ -76,7 +83,7 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
             feedAdapter = FeedAdapter(
                 context,
                 mutableSetOf(),
-                onClickShare = { Unit }
+                onClickShare = { joke -> startShareIntent(joke.value) }
             )
         }
 
@@ -84,6 +91,19 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
             adapter = feedAdapter
             layoutManager = LinearLayoutManager(context)
         }
+    }
+
+    private fun startShareIntent(value: String) {
+        val sendIntent: Intent = Intent().apply {
+            action = ACTION_SEND
+            putExtra(EXTRA_TEXT, value)
+            type = SHARE_TYPE
+        }
+
+        val shareIntent = Intent.createChooser(
+            sendIntent, context?.getString(R.string.share_intent_title)
+        )
+        startActivity(shareIntent)
     }
 
     override fun onResume() {

--- a/app/src/main/res/drawable/shape_category.xml
+++ b/app/src/main/res/drawable/shape_category.xml
@@ -2,7 +2,8 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorPrimary" />
+            <stroke android:width="1dp" android:color="@color/colorPrimary" />
+            <solid android:color="@android:color/transparent" />
             <corners android:radius="@dimen/one_measure_small" />
         </shape>
     </item>

--- a/app/src/main/res/layout/item_feed.xml
+++ b/app/src/main/res/layout/item_feed.xml
@@ -39,7 +39,6 @@
             android:paddingEnd="@dimen/two_measures"
             android:paddingBottom="@dimen/one_measure_small"
             android:textAllCaps="true"
-            android:textColor="@android:color/white"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="@+id/text_joke_value"
@@ -47,9 +46,10 @@
             tools:text="Aleaiactaest" />
 
         <ImageView
-            android:id="@+id/imageView"
+            android:id="@+id/icon_share"
             android:layout_width="@dimen/four_measures"
             android:layout_height="@dimen/four_measures"
+            android:background="?selectableItemBackgroundBorderless"
             android:contentDescription="@string/feed_share_button"
             android:src="@drawable/ic_share_black"
             app:layout_constraintEnd_toEndOf="@+id/text_joke_value"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="feed_standard_message">Your search results\n will be shown here</string>
 
     <string name="share_intent_title">Share this surprising fact</string>
+    <string name="share_intent_message">Hey, did you know that? %1$s </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="error_service_instability">It seems our servers are facing issues right now. Please, try again later.</string>
     <string name="error_no_connection">Please, check your internet connection and try again.</string>
     <string name="feed_standard_message">Your search results\n will be shown here</string>
+
+    <string name="share_intent_title">Share this surprising fact</string>
 </resources>


### PR DESCRIPTION
# Description

Add share intent to Fragment; and
Add click listener to icon.

Closes #12 and #24 

# What device was it tested on?

- [x] Physical - Android 9 - API 28 (Xiaomi Mi9 SE) 
- [ ] Emulator - Android 5 - API 21 (Pixel 3)
- [ ] N/A

# How to test:

* Open the app;
* Find a joke;
* Click on share icon; and
* Choose app.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have implemented remote config for the feature
