### PR TITLE
feat(search-results): add flowable to allow back pressure on feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Replace Maybes with Flowables to allow back pressure on searches
 - Changed README.md to present better the project
 - Text showing on the toolbar is now the the one on the wireframe

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/core/extensions/ObservableExtensions.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/core/extensions/ObservableExtensions.kt
@@ -4,7 +4,6 @@ import hu.akarnokd.rxjava3.bridge.RxJavaBridge
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
-import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
 
@@ -32,8 +31,5 @@ fun Completable.subscribeOnIO(): Completable =
 fun <T : Any> Flowable<out T>.subscribeOnIO(): Flowable<out T> =
     subscribeOn(Schedulers.io())
 
-fun <T : Any> Maybe<out T>.subscribeOnIO(): Maybe<out T> =
-    subscribeOn(Schedulers.io())
-
-fun <T : Any> Maybe<out T>.observeOnMain(): Maybe<out T> =
+fun <T : Any> Flowable<out T>.observeOnMain(): Flowable<out T> =
     observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImpl.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImpl.kt
@@ -6,8 +6,7 @@ import com.leehendryp.stoneandroidchallenge.feed.data.remote.RemoteDataSource
 import com.leehendryp.stoneandroidchallenge.feed.domain.JokeRepository
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
 import io.reactivex.rxjava3.core.Completable
-import io.reactivex.rxjava3.core.Maybe
-import java.util.concurrent.TimeUnit
+import io.reactivex.rxjava3.core.Flowable
 import javax.inject.Inject
 
 class JokeRepositoryImpl @Inject constructor(
@@ -15,26 +14,16 @@ class JokeRepositoryImpl @Inject constructor(
     private val remoteSource: RemoteDataSource,
     private val localSource: LocalDataSource
 ) : JokeRepository {
-    companion object {
-        private const val BUFFER_CAPACITY = 20
-    }
-
-    override fun search(query: String): Maybe<List<Joke>> {
+    override fun search(query: String): Flowable<Joke> {
         return if (networkUtils.isInternetAvailable()) remoteSearch(query)
-            .doAfterSuccess { response -> response.forEach { save(it) } }
+            .doOnNext { save(it) }
         else localSearch(query)
     }
 
     override fun save(joke: Joke): Completable = localSource.save(joke)
 
-    private fun remoteSearch(query: String): Maybe<List<Joke>> = remoteSource.search(query)
-        .flatMap { response -> Maybe.just(response.toJokeList()) }
+    private fun remoteSearch(query: String): Flowable<Joke> = remoteSource.search(query)
+        .map { response -> response.toJoke() }
 
-    private fun localSearch(query: String): Maybe<List<Joke>> {
-        return localSource.search(query)
-            .timeout(10, TimeUnit.SECONDS)
-            .onBackpressureBuffer(BUFFER_CAPACITY)
-            .toList()
-            .flatMapMaybe { Maybe.just(it) }
-    }
+    private fun localSearch(query: String): Flowable<Joke> = localSource.search(query)
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSource.kt
@@ -1,8 +1,8 @@
 package com.leehendryp.stoneandroidchallenge.feed.data.remote
 
 import com.leehendryp.stoneandroidchallenge.feed.data.entities.JokeResponse
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 
 interface RemoteDataSource {
-    fun search(query: String): Maybe<List<JokeResponse>>
+    fun search(query: String): Flowable<JokeResponse>
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImpl.kt
@@ -3,31 +3,18 @@ package com.leehendryp.stoneandroidchallenge.feed.data.remote
 import com.leehendryp.stoneandroidchallenge.core.extensions.getThrowable
 import com.leehendryp.stoneandroidchallenge.feed.data.entities.JokeResponse
 import com.leehendryp.stoneandroidchallenge.feed.data.entities.ResultResponse
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 import javax.inject.Inject
 import retrofit2.Response
 
-class RemoteDataSourceImpl @Inject constructor(private val api: JokesApi) :
-    RemoteDataSource {
-    companion object {
-        private const val REMOTE_SOURCE_ERROR = "Could not fetch data from remote source"
-
-        private class RemoteJokeListFetchException(message: String) : Throwable(message)
-    }
-
-    override fun search(query: String): Maybe<List<JokeResponse>> {
+class RemoteDataSourceImpl @Inject constructor(private val api: JokesApi) : RemoteDataSource {
+    override fun search(query: String): Flowable<JokeResponse> {
         return api.search(query)
-            .flatMap { response ->
+            .flattenAsFlowable { response ->
                 if (response.isSuccessful) response.retrieveJokeList()
-                else Maybe.error(response.getThrowable())
+                else throw response.getThrowable()
             }
     }
 
-    private fun Response<ResultResponse>.retrieveJokeList(): Maybe<List<JokeResponse>>? {
-        val jokeList = body()?.jokeList
-
-        return if (jokeList != null) Maybe.just(jokeList)
-        else Maybe.error(RemoteJokeListFetchException(REMOTE_SOURCE_ERROR)
-        )
-    }
+    private fun Response<ResultResponse>.retrieveJokeList() = body()?.jokeList
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/JokeRepository.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/JokeRepository.kt
@@ -2,9 +2,9 @@ package com.leehendryp.stoneandroidchallenge.feed.domain
 
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
 import io.reactivex.rxjava3.core.Completable
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 
 interface JokeRepository {
-    fun search(query: String): Maybe<List<Joke>>
+    fun search(query: String): Flowable<Joke>
     fun save(joke: Joke): Completable
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCase.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCase.kt
@@ -1,8 +1,8 @@
 package com.leehendryp.stoneandroidchallenge.feed.domain.usecases
 
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 
 interface SearchJokeUseCase {
-    fun execute(query: String): Maybe<List<Joke>>
+    fun execute(query: String): Flowable<Joke>
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCaseImpl.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCaseImpl.kt
@@ -2,11 +2,11 @@ package com.leehendryp.stoneandroidchallenge.feed.domain.usecases
 
 import com.leehendryp.stoneandroidchallenge.feed.domain.JokeRepository
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 import javax.inject.Inject
 
 class SearchJokeUseCaseImpl @Inject constructor(
     private val repository: JokeRepository
 ) : SearchJokeUseCase {
-    override fun execute(query: String): Maybe<List<Joke>> = repository.search(query)
+    override fun execute(query: String): Flowable<Joke> = repository.search(query)
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedViewModel.kt
@@ -17,6 +17,9 @@ class FeedViewModel @Inject constructor(
     private val compositeDisposable: CompositeDisposable,
     private val searchJokeUseCase: SearchJokeUseCase
 ) : ViewModel() {
+    companion object {
+        private const val BUFFER_COUNT = 20
+    }
 
     val state: BehaviorSubject<FeedState> by lazy {
         BehaviorSubject.create<FeedState>()
@@ -30,8 +33,9 @@ class FeedViewModel @Inject constructor(
                 .observeOnMain()
                 .doOnSubscribe { state(Loading) }
                 .doFinally { state(Default) }
+                .buffer(BUFFER_COUNT)
                 .subscribeBy(
-                    onSuccess = { jokeList -> state(Success(jokeList)) },
+                    onNext = { jokeList -> state(Success(jokeList)) },
                     onError = { error -> state(Error(error)) }
                 )
         )

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/core/DTOs.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/core/DTOs.kt
@@ -55,6 +55,12 @@ object DTOs {
         jokeThreeResponse.toJoke().toRoomJoke()
     )
 
+    val jokeResponseFlowable: Flowable<JokeResponse> = Flowable.just(
+        jokeOneResponse,
+        jokeTwoResponse,
+        jokeThreeResponse
+    )
+
     val jokeFlowable: Flowable<Joke> = Flowable.just(
         jokeOneResponse.toJoke(),
         jokeTwoResponse.toJoke(),

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImplTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImplTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyOrder
-import io.reactivex.rxjava3.core.Maybe
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -39,13 +38,14 @@ class JokeRepositoryImplTest : RxUnitTest() {
     fun `should fetch data from remote source if network is available`() {
         every { networkUtils.isInternetAvailable() } returns true
 
-        every { remoteSource.search(any()) } returns Maybe.just(DTOs.correctJokeResponses)
+        every { remoteSource.search(any()) } returns DTOs.jokeResponseFlowable
 
         repo.search("")
             .test()
             .assertComplete()
             .assertNoErrors()
-            .assertResult(DTOs.jokes)
+            .values()
+            .containsAll(DTOs.jokes)
 
         verify(exactly = 1) { remoteSource.search(any()) }
         verify(exactly = 0) { localSource.search(any()) }
@@ -61,7 +61,8 @@ class JokeRepositoryImplTest : RxUnitTest() {
             .test()
             .assertComplete()
             .assertNoErrors()
-            .assertResult(DTOs.jokes)
+            .values()
+            .containsAll(DTOs.jokes)
 
         verify(exactly = 0) { remoteSource.search(any()) }
         verify(exactly = 1) { localSource.search(any()) }
@@ -71,7 +72,7 @@ class JokeRepositoryImplTest : RxUnitTest() {
     fun `should save data locally after remote data fetch if network is available`() {
         every { networkUtils.isInternetAvailable() } returns true
 
-        every { remoteSource.search(any()) } returns Maybe.just(DTOs.correctJokeResponses)
+        every { remoteSource.search(any()) } returns DTOs.jokeResponseFlowable
 
         repo.search("")
             .test()

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImplTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImplTest.kt
@@ -49,7 +49,8 @@ class RemoteDataSourceImplTest : RxUnitTest() {
             .test()
             .assertComplete()
             .assertNoErrors()
-            .assertResult(DTOs.correctJokeResponses)
+            .values()
+            .containsAll(DTOs.correctJokeResponses)
     }
 
     @Test

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCaseImplTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/domain/usecases/SearchJokeUseCaseImplTest.kt
@@ -3,11 +3,10 @@ package com.leehendryp.stoneandroidchallenge.feed.domain.usecases
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.leehendryp.stoneandroidchallenge.core.DTOs
 import com.leehendryp.stoneandroidchallenge.core.RxUnitTest
-import com.leehendryp.stoneandroidchallenge.feed.data.toJokeList
 import com.leehendryp.stoneandroidchallenge.feed.domain.JokeRepository
 import io.mockk.every
 import io.mockk.mockk
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -27,22 +26,21 @@ class SearchJokeUseCaseImplTest : RxUnitTest() {
 
     @Test
     fun `should return joke list from successful repository data fetch attempt`() {
-        val jokeList = DTOs.correctJokeResponses.toJokeList()
-
-        every { repository.search(any()) } returns Maybe.just(jokeList)
+        every { repository.search(any()) } returns DTOs.jokeFlowable
 
         useCase.execute("")
             .test()
             .assertComplete()
             .assertNoErrors()
-            .assertResult(jokeList)
+            .values()
+            .containsAll(DTOs.jokes)
     }
 
     @Test
     fun `should return error from failed repository data fetch attempt`() {
         val error = Throwable()
 
-        every { repository.search(any()) } returns Maybe.error(error)
+        every { repository.search(any()) } returns Flowable.error(error)
 
         useCase.execute("")
             .test()

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/presentation/FeedViewModelTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/presentation/FeedViewModelTest.kt
@@ -13,7 +13,7 @@ import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedView
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verifyOrder
-import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Observer
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import org.junit.Before
@@ -49,7 +49,7 @@ class FeedViewModelTest : RxUnitTest() {
 
     @Test
     fun `should emit success state with joke list data upon successful use case execution`() {
-        every { searchJokeUseCase.execute(any()) } returns Maybe.just(DTOs.jokes)
+        every { searchJokeUseCase.execute(any()) } returns DTOs.jokeFlowable
 
         viewModel.search("")
 
@@ -65,7 +65,7 @@ class FeedViewModelTest : RxUnitTest() {
     fun `should emit error state with error data upon failed use case execution`() {
         val error = Throwable()
 
-        every { searchJokeUseCase.execute(any()) } returns Maybe.error(error)
+        every { searchJokeUseCase.execute(any()) } returns Flowable.error(error)
 
         viewModel.search("")
 


### PR DESCRIPTION
# Description

Replace `Maybe<List<Joke>>` and `Maybe<List<JokeResponse>>`returns with `Flowable<Joke>`and `Flowable <JokeResponse >` ones, to allow back pressure and improve app performance.

Closes #40 

# What device was it tested on?

- [x] Physical - Android 9 - API 28 (Xiaomi Mi9 SE) 
- [ ] Emulator - Android 5 - API 21 (Pixel 3)
- [ ] N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have implemented remote config for the feature
