### PR TITLE
fix(no-result): add variable to controle if users should be warned  …

### DIFF
--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImpl.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/JokeRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.leehendryp.stoneandroidchallenge.feed.domain.JokeRepository
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class JokeRepositoryImpl @Inject constructor(
@@ -14,6 +15,9 @@ class JokeRepositoryImpl @Inject constructor(
     private val remoteSource: RemoteDataSource,
     private val localSource: LocalDataSource
 ) : JokeRepository {
+    companion object {
+        private const val LOCAL_TIMEOUT: Long = 10
+    }
     override fun search(query: String): Flowable<Joke> {
         return if (networkUtils.isInternetAvailable()) remoteSearch(query)
             .doOnNext { save(it) }
@@ -26,4 +30,5 @@ class JokeRepositoryImpl @Inject constructor(
         .map { response -> response.toJoke() }
 
     private fun localSearch(query: String): Flowable<Joke> = localSource.search(query)
+        .timeout(LOCAL_TIMEOUT, TimeUnit.SECONDS)
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/data/remote/RemoteDataSourceImpl.kt
@@ -16,5 +16,7 @@ class RemoteDataSourceImpl @Inject constructor(private val api: JokesApi) : Remo
             }
     }
 
-    private fun Response<ResultResponse>.retrieveJokeList() = body()?.jokeList
+    private fun Response<ResultResponse>.retrieveJokeList(): List<JokeResponse> {
+        return body()?.jokeList ?: listOf()
+    }
 }

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/view/FeedFragment.kt
@@ -26,6 +26,7 @@ import com.leehendryp.stoneandroidchallenge.core.extensions.visible
 import com.leehendryp.stoneandroidchallenge.databinding.FragmentFeedBinding
 import com.leehendryp.stoneandroidchallenge.feed.presentation.FreeTextSearcher
 import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedState
+import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedState.Default
 import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedState.Error
 import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedState.Loading
 import com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel.FeedState.Success
@@ -132,6 +133,7 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
             Loading -> clearFeed()
             is Success -> updateFeed(state)
             is Error -> showErrorDialog(state)
+            is Default -> showNoResultFeedback(state.shouldWarnNoResult)
         }
     }
 
@@ -146,16 +148,7 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
     private fun clearFeed() = feedAdapter.clearList()
 
     private fun updateFeed(state: Success) {
-        with(state.data) {
-            if (this.isEmpty()) {
-                showNoResultDialog()
-                binding.textStandardMessage.visible()
-            } else {
-                binding.textStandardMessage.gone()
-            }
-
-            feedAdapter.update(this.toSet())
-        }
+        feedAdapter.update(state.data.toSet())
     }
 
     private fun showNoResultDialog() {
@@ -172,6 +165,17 @@ class FeedFragment : BaseFragment(), FreeTextSearcher {
             is TimeoutException -> showErrorDialog(message = R.string.error_no_connection)
             is IOException -> showErrorDialog(message = R.string.error_no_connection)
             else -> showErrorDialog()
+        }
+    }
+
+    private fun showNoResultFeedback(show: Boolean) {
+        binding.textStandardMessage.apply {
+            if (show) {
+                visible()
+                showNoResultDialog()
+            } else {
+                gone()
+            }
         }
     }
 

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedState.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedState.kt
@@ -3,7 +3,7 @@ package com.leehendryp.stoneandroidchallenge.feed.presentation.viewmodel
 import com.leehendryp.stoneandroidchallenge.feed.domain.model.Joke
 
 sealed class FeedState {
-    object Default : FeedState()
+    data class Default(var shouldWarnNoResult: Boolean = false) : FeedState()
     object Loading : FeedState()
     data class Success(val data: List<Joke>) : FeedState()
     data class Error(val error: Throwable) : FeedState()

--- a/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/leehendryp/stoneandroidchallenge/feed/presentation/viewmodel/FeedViewModel.kt
@@ -21,27 +21,37 @@ class FeedViewModel @Inject constructor(
         private const val BUFFER_COUNT = 20
     }
 
-    val state: BehaviorSubject<FeedState> by lazy {
-        BehaviorSubject.create<FeedState>()
-            .apply { onNext(Default) }
-    }
+    val state: BehaviorSubject<FeedState> by lazy { initState() }
+    private var shouldWarnNoResult: Boolean = false
 
     fun search(query: String) {
         compositeDisposable.add(
             searchJokeUseCase.execute(query)
                 .subscribeOnIO()
                 .observeOnMain()
-                .doOnSubscribe { state(Loading) }
-                .doFinally { state(Default) }
+                .doOnSubscribe {
+                    state(Loading)
+                    warnNoResult(true)
+                }
+                .doFinally { state(Default(shouldWarnNoResult)) }
                 .buffer(BUFFER_COUNT)
                 .subscribeBy(
                     onNext = { jokeList -> state(Success(jokeList)) },
-                    onError = { error -> state(Error(error)) }
+                    onError = { error ->
+                        state(Error(error))
+                        warnNoResult(false)
+                    }
                 )
         )
     }
 
+    private fun initState() = BehaviorSubject.create<FeedState>()
+
     private fun state(feedState: FeedState) = state.onNext(feedState)
+
+    private fun warnNoResult(warn: Boolean) {
+        shouldWarnNoResult = warn
+    }
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,8 @@
 
     <string name="feed_share_button">Share button</string>
     <string name="feed_no_results">No results</string>
-    <string name="feed_try_new_keywords">Please, try again but with different words.</string>
+    <string name="feed_try_new_keywords">Please, try again with different words.</string>
+    <string name="feed_standard_message">Your search results\n will be shown here</string>
 
     <string name="item_category_label_uncategorized">Uncategorized</string>
 
@@ -13,7 +14,6 @@
     <string name="error_my_bad">Oops, that\'s embarrassing… My bad. If the issue persists, try updating the app. </string>
     <string name="error_service_instability">It seems our servers are facing issues right now. Please, try again later.</string>
     <string name="error_no_connection">Please, check your internet connection and try again.</string>
-    <string name="feed_standard_message">Your search results\n will be shown here</string>
 
     <string name="share_intent_title">Share this surprising fact</string>
     <string name="share_intent_message">Hey, did you know that? %1$s </string>

--- a/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/presentation/FeedViewModelTest.kt
+++ b/app/src/test/java/com/leehendryp/stoneandroidchallenge/feed/presentation/FeedViewModelTest.kt
@@ -54,10 +54,9 @@ class FeedViewModelTest : RxUnitTest() {
         viewModel.search("")
 
         verifyOrder {
-            stateObserver.onNext(Default)
             stateObserver.onNext(Loading)
             stateObserver.onNext(Success(DTOs.jokes))
-            stateObserver.onNext(Default)
+            stateObserver.onNext(Default(true))
         }
     }
 
@@ -70,10 +69,36 @@ class FeedViewModelTest : RxUnitTest() {
         viewModel.search("")
 
         verifyOrder {
-            stateObserver.onNext(Default)
             stateObserver.onNext(Loading)
             stateObserver.onNext(Error(error))
-            stateObserver.onNext(Default)
+            stateObserver.onNext(Default(false))
+        }
+    }
+
+    @Test
+    fun `should emit default state with warning for no result upon successful use case execution with no results`() {
+        every { searchJokeUseCase.execute(any()) } returns Flowable.empty()
+
+        viewModel.search("")
+
+        verifyOrder {
+            stateObserver.onNext(Loading)
+            stateObserver.onNext(Default(true))
+        }
+    }
+
+    @Test
+    fun `should emit default state without warning for no result upon failed use case execution`() {
+        val error = Throwable()
+
+        every { searchJokeUseCase.execute(any()) } returns Flowable.error(error)
+
+        viewModel.search("")
+
+        verifyOrder {
+            stateObserver.onNext(Loading)
+            stateObserver.onNext(Error(error))
+            stateObserver.onNext(Default(false))
         }
     }
 }


### PR DESCRIPTION
# Description

Fix bug introduced by the replacement of `Maybe<List<Joke>>` with `Flowable<Joke>`. As empty Flowables do not call `onNext()`, users were lacking the proper feedback upon unfruitful – yet successful – searches, which was present before the replacement due to Maybe's `onSuccess()`.

Closes #42 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have implemented remote config for the feature
